### PR TITLE
Permettre à l'usager d'obtenir un nouveau lien sans passer par le support

### DIFF
--- a/src/controllers/user/magic-link.ts
+++ b/src/controllers/user/magic-link.ts
@@ -5,6 +5,7 @@ import {
 } from '../../managers/user';
 import { InvalidEmailError, InvalidMagicLinkError } from '../../errors';
 import { z, ZodError } from 'zod';
+import { isEmpty } from 'lodash';
 
 export const postSendMagicLinkController = async (
   req: Request,
@@ -116,8 +117,13 @@ export const postSignInWithMagicLinkController = async (
     next();
   } catch (error) {
     if (error instanceof InvalidMagicLinkError || error instanceof ZodError) {
+      if (isEmpty(req.session.email)) {
+        return res.redirect(
+          `/users/start-sign-in?notification=invalid_magic_link`
+        );
+      }
       return res.redirect(
-        `/users/start-sign-in?notification=invalid_magic_link`
+        `/users/start-sign-in?notification=invalid_magic_link_with_reinit`
       );
     }
 

--- a/src/controllers/user/magic-link.ts
+++ b/src/controllers/user/magic-link.ts
@@ -123,10 +123,25 @@ export const postSignInWithMagicLinkController = async (
         );
       }
       return res.redirect(
-        `/users/start-sign-in?notification=invalid_magic_link_with_reinit`
+        `/users/send-magic-link-again`
       );
     }
 
     next(error);
   }
 };
+
+export const getSendMagicLinkAgainController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const email = req.session.email;
+    return res.render('user/send-magic-link-again', { 
+      csrfToken: req.csrfToken(),
+    });
+  } catch (error) {
+    next(error);
+  }
+}

--- a/src/notification-messages.ts
+++ b/src/notification-messages.ts
@@ -35,12 +35,6 @@ Veuillez cliquer sur « Réinitialiser » pour recevoir un nouveau lien`,
 
     Pour recevoir un nouveau lien, entrez votre adresse e-mail ci-dessous.`,
   },
-  invalid_magic_link_with_reinit: {
-    type: 'warning',
-    description: `Le lien que vous avez utilisé est invalide ou expiré.
-
-Cliquez sur le bouton « Envoyer le lien » pour obtenir un nouveau lien.`,
-  },
   password_change_success: {
     type: 'success',
     description: `Votre mot de passe a été mis à jour.

--- a/src/notification-messages.ts
+++ b/src/notification-messages.ts
@@ -31,7 +31,15 @@ Veuillez cliquer sur « Réinitialiser » pour recevoir un nouveau lien`,
   },
   invalid_magic_link: {
     type: 'warning',
-    description: 'Le lien que vous avez utilisé est invalide ou expiré.',
+    description: `Le lien que vous avez utilisé est invalide ou expiré.
+
+    Pour recevoir un nouveau lien, entrez votre adresse e-mail ci-dessous.`,
+  },
+  invalid_magic_link_with_reinit: {
+    type: 'warning',
+    description: `Le lien que vous avez utilisé est invalide ou expiré.
+
+Cliquez sur le bouton « Envoyer le lien » pour obtenir un nouveau lien.`,
   },
   password_change_success: {
     type: 'success',

--- a/src/routers/user.ts
+++ b/src/routers/user.ts
@@ -36,6 +36,7 @@ import {
   getSignInWithMagicLinkController,
   postSendMagicLinkController,
   postSignInWithMagicLinkController,
+  getSendMagicLinkAgainController,
 } from '../controllers/user/magic-link';
 import {
   getChangePasswordController,
@@ -152,6 +153,12 @@ export const userRouter = () => {
     checkUserSignInRequirementsMiddleware,
     issueSessionOrRedirectController
   );
+  userRouter.get(
+    '/send-magic-link-again',
+    csrfProtectionMiddleware,
+    checkEmailInSessionMiddleware,
+    getSendMagicLinkAgainController
+  )
   userRouter.get(
     '/reset-password',
     csrfProtectionMiddleware,

--- a/src/views/user/send-magic-link-again.ejs
+++ b/src/views/user/send-magic-link-again.ejs
@@ -1,0 +1,30 @@
+<div class="card-container">
+    <div class="fr-card">
+        <div class="fr-card__body">
+            <div class="fr-card__content">
+                <h4 class="fr-card__title">
+                    Accéder au compte
+                </h4>
+                <div class="fr-card__desc">
+                    <div>
+                        <div class="fr-alert fr-alert--warning">
+                            <p class="fr-alert__title">Lien expiré</p>
+                            <p class="alert-description">Le lien est invalide ou expiré.</p>
+                        </div>
+                        <br>
+                        <div class="card-button-container">
+                            <div id="magic-link-icon-inline">
+                                <img src="/assets/magic-link.svg" alt="">
+                            </div>
+                            <form action="/users/send-magic-link" method="post">
+                                <input type="hidden" name="_csrf" value="<%= csrfToken; %>" autocomplete="off">
+
+                                <%- include('../partials/card-button-container.ejs', {label: 'Renvoyer le lien'}) %>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Actuellement quand l'usager clique trop tard sur le lien magique reçu par mail, il n'a qu'un message austère "Le lien que vous avez reçu est invalide ou expiré."
=> Panique, appel au support, tristesse.

Cette PR vise à améliorer tout ça.

**Cas numéro 1 :** l'usager n'a plus qu'à cliquer sur le bouton. Techniquement c'est une nouvelle page, sinon ça faisait trop de `if` dans les templates. J'espère que j'ai fait comme il faut. :)

<img width="620" alt="Capture d’écran 2023-05-22 à 15 29 53" src="https://github.com/betagouv/moncomptepro/assets/1035145/2e1f2d30-6494-4c01-b10c-5b23087ed77a">


**Cas numéro 2 :** on ne peut pas régénérer le lien directement parce que (pour plein de raisons) on ne connaît pas le mail de l'usager. Qu'à cela ne tienne, on améliore quand même le message pour ajouter un petit CTA et que la personne se sente moins coincée. 

![Capture d’écran 2023-03-21 à 11 25 16](https://user-images.githubusercontent.com/1035145/226579749-7d887d00-b2b5-425c-b65d-f36c178a7e53.png)
