### PR TITLE
Update fixture.sql for outline scope

### DIFF
--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -601,7 +601,7 @@ VALUES
    ARRAY [
      'https://outline-operateur.osc-secnum-fr1.scalingo.io/'
      ],
-   'openid email profile',
+   'openid profile email',
    'https://outline-operateur.osc-secnum-fr1.scalingo.io/',
    'La base de connaissances de votre équipe.',
    null, null, null, null)


### PR DESCRIPTION
Reorder scope to fit outline doc. 

Dans outline, j'ai cette erreur : "UnauthorizedError: Neither a name or username was returned in the profile parameter, but at least one is required.

J'ai pensé qu'en remettant le scope dans l'ordre attendu par outline, ça pourrait aider.