### PR TITLE
chore: remove oidc warning about double parsing

### DIFF
--- a/src/routers/api.ts
+++ b/src/routers/api.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response, Router } from 'express';
+import { NextFunction, Request, Response, Router, urlencoded } from 'express';
 import {
   getOrganizationInfoController,
   postForceJoinOrganizationController,
@@ -12,6 +12,14 @@ import { API_AUTH_PASSWORD, API_AUTH_USERNAME } from '../env';
 
 export const apiRouter = () => {
   const apiRouter = Router();
+
+  apiRouter.use((req, res, next) => {
+    res.set('Pragma', 'no-cache');
+    res.set('Cache-Control', 'no-cache, no-store');
+    next();
+  });
+
+  apiRouter.use(urlencoded({ extended: false }));
 
   apiRouter.get(
     '/organization-info',

--- a/src/routers/main.ts
+++ b/src/routers/main.ts
@@ -22,10 +22,9 @@ export const mainRouter = (app: Express) => {
     next();
   });
 
-  mainRouter.use(urlencoded({ extended: false }));
-
   mainRouter.get(
     '/',
+    urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
     checkUserSignInRequirementsMiddleware,
     getHomeController
@@ -33,6 +32,7 @@ export const mainRouter = (app: Express) => {
 
   mainRouter.get(
     '/personal-information',
+    urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
     csrfProtectionMiddleware,
     checkUserSignInRequirementsMiddleware,
@@ -41,6 +41,7 @@ export const mainRouter = (app: Express) => {
 
   mainRouter.post(
     '/personal-information',
+    urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
     csrfProtectionMiddleware,
     rateLimiterMiddleware,
@@ -50,6 +51,7 @@ export const mainRouter = (app: Express) => {
 
   mainRouter.get(
     '/manage-organizations',
+    urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
     csrfProtectionMiddleware,
     checkUserSignInRequirementsMiddleware,
@@ -58,6 +60,7 @@ export const mainRouter = (app: Express) => {
 
   mainRouter.get(
     '/reset-password',
+    urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
     csrfProtectionMiddleware,
     checkUserSignInRequirementsMiddleware,
@@ -66,6 +69,7 @@ export const mainRouter = (app: Express) => {
 
   mainRouter.get(
     '/help',
+    urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
     csrfProtectionMiddleware,
     getHelpController


### PR DESCRIPTION
using urlencoded on / parse the params even for /oauth oidc's routes which uses its own parser.