### PR TITLE
fix: CD12 - add new redirect-uri

### DIFF
--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -345,7 +345,8 @@ VALUES
    'lmB72ac+JKZPUmg3+vlo9dPMkCRnFRyz+NE+lslJFX07V4JObFZ0H/vXnXB5Jzu1s96KLU5FmirsfqsKLeVukHBO6Vmy6dfcwKfjMGgWTBD6ik01KUcFq2f3bx5nO6yj',
    ARRAY [
      'https://keycloak.lab.aveyron.fr/realms/MCP/broker/oidc/endpoint',
-     'https://keycloak.lab.aveyron.fr/realms/MCP/broker/moncomptepro/endpoint'
+     'https://keycloak.lab.aveyron.fr/realms/MCP/broker/moncomptepro/endpoint',
+     'https://keycloak.lab.aveyron.fr/realms/MCP/broker/moncomptepro-staging/endpoint'
      ],
    ARRAY [
      'https://keycloak.lab.aveyron.fr'


### PR DESCRIPTION
Add a new redirect_uri to split Keycloak IDPs for MonComptePro