### PR TITLE
Allowing profile for Grist dev environment

### DIFF
--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -322,11 +322,13 @@ VALUES
    '031da300506ac31fac6feaf88575b94b886eae7a68c64327ee03e0fa635ae9ae28572e4de53bb435b3fce4f8ac8484334d71de48f3c9abed3709c730173e0fe0',
    ARRAY [
      'https://grist.dev.incubateur.anct.gouv.fr/_oauth',
-     'http://localhost:8484/_oauth'
+     'http://localhost:8484/_oauth',
+     'http://localhost:8484/oauth2/callback'
      ],
    ARRAY [
      'https://grist.dev.incubateur.anct.gouv.fr',
-     'http://localhost:8484'
+     'http://localhost:8484',
+     'http://localhost:8484/o/docs/signed-out'
      ],
    'openid email organization organizations profile',
    'https://grist.dev.incubateur.anct.gouv.fr',

--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -328,7 +328,7 @@ VALUES
      'https://grist.dev.incubateur.anct.gouv.fr',
      'http://localhost:8484'
      ],
-   'openid email organization organizations',
+   'openid email organization organizations profile',
    'https://grist.dev.incubateur.anct.gouv.fr',
    'Saisir et manipuler collaborativement les données.',
    null, null, null, null),


### PR DESCRIPTION
We'd like to allow fetching profile information from the Grist dev environment, so we can retrieve the family and given name of the users.

Also we'd like to test new callback / sign out URLs related to that development (in draft):
https://github.com/gristlabs/grist-core/pull/717