### PR TITLE
feat: use zammad to send join email

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -33,6 +33,7 @@ env:
   SUPPORT_EMAIL_ADDRESS: "moncomptepro@yopmail.com"
   ZAMMAD_URL: ${{ secrets.ZAMMAD_URL }}
   ZAMMAD_TOKEN: ${{ secrets.ZAMMAD_TOKEN }}
+  MODERATION_TAG: "github-action-e2e-test"
 
 jobs:
   test:

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -31,6 +31,8 @@ env:
   CYPRESS_MAILSLURP_API_KEY: ${{ secrets.MAILSLURP_API_KEY }}
   SECURE_COOKIES: "false"
   SUPPORT_EMAIL_ADDRESS: "moncomptepro@yopmail.com"
+  ZAMMAD_URL: ${{ secrets.ZAMMAD_URL }}
+  ZAMMAD_TOKEN: ${{ secrets.ZAMMAD_TOKEN }}
 
 jobs:
   test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3"
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - 6379:6379
+
+  maildev:
+    image: maildev/maildev:2.1.0
+    ports:
+      - 1080:1080
+      - 1025:1025
+
+volumes:
+  postgres:

--- a/installation.md
+++ b/installation.md
@@ -107,6 +107,7 @@ SENTRY_DSN=
 SECURE_COOKIES="false"
 INSEE_CONSUMER_KEY=yourownkey
 INSEE_CONSUMER_SECRET=yourownsecret
+ZAMMAD_URL=http://zammad/
 EOT
 ```
 

--- a/installation.md
+++ b/installation.md
@@ -108,6 +108,7 @@ SECURE_COOKIES="false"
 INSEE_CONSUMER_KEY=yourownkey
 INSEE_CONSUMER_SECRET=yourownsecret
 ZAMMAD_URL=http://zammad/
+ZAMMAD_TOKEN=your_zammad_token
 EOT
 ```
 

--- a/migrations/1703247171649_add-zammad-ticket-id-on-moderations.js
+++ b/migrations/1703247171649_add-zammad-ticket-id-on-moderations.js
@@ -1,0 +1,17 @@
+//
+
+exports.shorthands = undefined;
+
+exports.up = async (pgm) => {
+  await pgm.db.query(`
+      ALTER TABLE moderations
+          ADD COLUMN ticket_id int;
+  `);
+};
+
+exports.down = async (pgm) => {
+  await pgm.db.query(`
+      ALTER TABLE moderations
+          DROP COLUMN ticket_id;
+  `);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "ts-mocha": "^10.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": "16.20.2"
       }
     },
     "node_modules/@babel/runtime": {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -15,6 +15,7 @@ export const {
   SUPPORT_EMAIL_ADDRESS = "moncomptepro@beta.gouv.fr",
   API_AUTH_USERNAME = "admin",
   API_AUTH_PASSWORD = "admin",
+  ZAMMAD_URL,
 } = process.env;
 
 export const DO_NOT_CHECK_EMAIL_DELIVERABILITY =

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -15,6 +15,7 @@ export const {
   SUPPORT_EMAIL_ADDRESS = "moncomptepro@beta.gouv.fr",
   API_AUTH_USERNAME = "admin",
   API_AUTH_PASSWORD = "admin",
+  ZAMMAD_TOKEN,
   ZAMMAD_URL,
 } = process.env;
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -17,6 +17,7 @@ export const {
   API_AUTH_PASSWORD = "admin",
   ZAMMAD_TOKEN,
   ZAMMAD_URL,
+  MODERATION_TAG = "moderation",
 } = process.env;
 
 export const DO_NOT_CHECK_EMAIL_DELIVERABILITY =

--- a/src/config/errors.ts
+++ b/src/config/errors.ts
@@ -73,3 +73,5 @@ export class OfficialContactEmailVerificationNotNeededError extends Error {}
 export class WebauthnRegistrationFailedError extends Error {}
 
 export class WebauthnAuthenticationFailedError extends Error {}
+
+export class SendZammadApiError extends Error {}

--- a/src/connectors/sendZammadMail.ts
+++ b/src/connectors/sendZammadMail.ts
@@ -1,5 +1,6 @@
 //
 
+import axios, { AxiosResponse } from "axios";
 import path from "node:path";
 import {
   DO_NOT_SEND_MAIL,
@@ -58,16 +59,17 @@ export async function sendZammadMail({
     return;
   }
 
-  const response = await fetch(CREATE_TICKET_ENDPOINT, {
-    headers: {
-      "content-type": "application/json",
-      Authorization: `Bearer ${ZAMMAD_TOKEN}`,
+  const { data: ticket }: AxiosResponse<{ id: number }> = await axios.post(
+    CREATE_TICKET_ENDPOINT,
+    {
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${ZAMMAD_TOKEN}`,
+      },
+      body: data,
+      method: "POST",
     },
-    body: JSON.stringify(data),
-    method: "POST",
-  });
+  );
 
-  const ticket = await response.json();
-
-  return ticket as { id: number };
+  return ticket;
 }

--- a/src/connectors/sendZammadMail.ts
+++ b/src/connectors/sendZammadMail.ts
@@ -55,7 +55,7 @@ export async function sendZammadMail({
   if (DO_NOT_SEND_MAIL) {
     console.log(`${template} mail not send to ${to}:`);
     console.log(data);
-    return { id: NaN };
+    return { id: null };
   }
 
   const { data: ticket }: AxiosResponse<{ id: number }> = await axios.post(

--- a/src/connectors/sendZammadMail.ts
+++ b/src/connectors/sendZammadMail.ts
@@ -9,7 +9,6 @@ import {
   ZAMMAD_URL,
 } from "../config/env";
 import { render } from "../services/renderer";
-import { LocalTemplate } from "./sendinblue";
 
 //
 
@@ -72,3 +71,19 @@ export async function sendZammadMail({
 
   return ticket;
 }
+
+//
+
+type LocalTemplate =
+| {
+    template: "unable-to-auto-join-organization";
+    params: { libelle: string };
+  }
+| {
+    template: "unable-to-find-sponsor";
+    params: {
+      given_name: string;
+      family_name: string;
+      libelle: string;
+    };
+  };

--- a/src/connectors/sendZammadMail.ts
+++ b/src/connectors/sendZammadMail.ts
@@ -1,7 +1,12 @@
 //
 
 import path from "node:path";
-import { DO_NOT_SEND_MAIL, ZAMMAD_TOKEN, ZAMMAD_URL } from "../config/env";
+import {
+  DO_NOT_SEND_MAIL,
+  MODERATION_TAG,
+  ZAMMAD_TOKEN,
+  ZAMMAD_URL,
+} from "../config/env";
 import { render } from "../services/renderer";
 import { LocalTemplate } from "./sendinblue";
 
@@ -12,7 +17,6 @@ const CREATE_TICKET_ENDPOINT = `${ZAMMAD_URL}/api/v1/tickets`;
 const EMAIL_TYPE_ID = 1;
 const GROUP_MONCOMPTEPRO = "MonComptePro";
 const GROUP_MONCOMPTEPRO_SENDER_ID = 1;
-const MODERATION_TAG = "moderation";
 const NORMAL_PRIORITY_ID = "1";
 
 //

--- a/src/connectors/sendZammadMail.ts
+++ b/src/connectors/sendZammadMail.ts
@@ -61,13 +61,12 @@ export async function sendZammadMail({
 
   const { data: ticket }: AxiosResponse<{ id: number }> = await axios.post(
     CREATE_TICKET_ENDPOINT,
+    data,
     {
       headers: {
         "content-type": "application/json",
         Authorization: `Bearer ${ZAMMAD_TOKEN}`,
       },
-      body: JSON.stringify(data),
-      method: "POST",
     },
   );
 

--- a/src/connectors/sendZammadMail.ts
+++ b/src/connectors/sendZammadMail.ts
@@ -1,0 +1,58 @@
+//
+
+import { chain } from "lodash";
+import { DO_NOT_SEND_MAIL, ZAMMAD_URL } from "../config/env";
+import { LocalTemplateSlug, RemoteTemplateSlug } from "./sendinblue";
+
+//
+
+export async function sendZammadMail({
+  to = [],
+  cc = [],
+  subject,
+  template,
+  params,
+  senderEmail = "moncomptepro@beta.gouv.fr",
+}: {
+  to: string[];
+  cc?: string[];
+  subject: string;
+  template: RemoteTemplateSlug | LocalTemplateSlug;
+  params: any;
+  senderEmail?: string;
+}) {
+  const CREATE_TICKET_ENDPOINT = `${ZAMMAD_URL}/api/v1/tickets`;
+  console.log("Sending mail to Zammad ", CREATE_TICKET_ENDPOINT);
+
+  const data = {
+    cc: undefined as { email: string }[] | undefined,
+    sender: {
+      name: "L’équipe MonComptePro",
+      email: senderEmail,
+    },
+    replyTo: {
+      name: "L’équipe MonComptePro",
+      email: senderEmail,
+    },
+    // Sendinblue allow a maximum of 99 recipients
+    to: chain(to)
+      .sampleSize(99)
+      .map((e) => ({ email: e }))
+      .value(),
+    subject,
+    params,
+    tags: [template],
+    headers: {
+      charset: "iso-8859-1",
+    },
+    templateId: 0,
+  };
+
+  if (DO_NOT_SEND_MAIL) {
+    console.log(`${template} mail not send to ${to}:`);
+    console.log(data);
+    return;
+  }
+
+  return Promise.reject("Not implemented");
+}

--- a/src/connectors/sendZammadMail.ts
+++ b/src/connectors/sendZammadMail.ts
@@ -66,7 +66,7 @@ export async function sendZammadMail({
         "content-type": "application/json",
         Authorization: `Bearer ${ZAMMAD_TOKEN}`,
       },
-      body: data,
+      body: JSON.stringify(data),
       method: "POST",
     },
   );

--- a/src/connectors/sendZammadMail.ts
+++ b/src/connectors/sendZammadMail.ts
@@ -56,7 +56,7 @@ export async function sendZammadMail({
   if (DO_NOT_SEND_MAIL) {
     console.log(`${template} mail not send to ${to}:`);
     console.log(data);
-    return;
+    return { id: NaN };
   }
 
   const { data: ticket }: AxiosResponse<{ id: number }> = await axios.post(

--- a/src/connectors/sendZammadMail.ts
+++ b/src/connectors/sendZammadMail.ts
@@ -1,6 +1,5 @@
 //
 
-import { sampleSize } from "lodash";
 import path from "node:path";
 import { DO_NOT_SEND_MAIL, ZAMMAD_TOKEN, ZAMMAD_URL } from "../config/env";
 import { render } from "../services/renderer";
@@ -11,22 +10,20 @@ import { LocalTemplate } from "./sendinblue";
 const CLOSED_STATE_ID = "4";
 const CREATE_TICKET_ENDPOINT = `${ZAMMAD_URL}/api/v1/tickets`;
 const EMAIL_TYPE_ID = 1;
-const GROUP_MON_COMPTE_PRO = "MonComptePro";
-const GROUP_MON_COMPTE_PRO_SENDER_ID = 1;
+const GROUP_MONCOMPTEPRO = "MonComptePro";
+const GROUP_MONCOMPTEPRO_SENDER_ID = 1;
 const MODERATION_TAG = "moderation";
 const NORMAL_PRIORITY_ID = "1";
 
 //
 
 export async function sendZammadMail({
-  to = [],
-  cc = [],
+  to,
   subject,
   template,
   params,
 }: {
-  to: string[];
-  cc?: string[];
+  to: string;
   subject: string;
 } & LocalTemplate) {
   const body = await render(
@@ -36,16 +33,16 @@ export async function sendZammadMail({
 
   const data = {
     title: subject,
-    group: GROUP_MON_COMPTE_PRO,
-    customer_id: `guess:${to.at(0)}`,
+    group: GROUP_MONCOMPTEPRO,
+    customer_id: `guess:${to}`,
     state_id: CLOSED_STATE_ID,
     priority_id: NORMAL_PRIORITY_ID,
     article: {
-      from: GROUP_MON_COMPTE_PRO,
-      to: sampleSize(to, 99).join(","),
+      from: GROUP_MONCOMPTEPRO,
+      to,
       body,
       type_id: EMAIL_TYPE_ID,
-      sender_id: GROUP_MON_COMPTE_PRO_SENDER_ID,
+      sender_id: GROUP_MONCOMPTEPRO_SENDER_ID,
       content_type: "text/html",
     },
     tags: [MODERATION_TAG, template].join(","),

--- a/src/connectors/sendZammadMail.ts
+++ b/src/connectors/sendZammadMail.ts
@@ -4,14 +4,13 @@ import { sampleSize } from "lodash";
 import path from "node:path";
 import { DO_NOT_SEND_MAIL, ZAMMAD_TOKEN, ZAMMAD_URL } from "../config/env";
 import { render } from "../services/renderer";
-import { LocalTemplateSlug } from "./sendinblue";
+import { LocalTemplate } from "./sendinblue";
 
 //
 
 const CLOSED_STATE_ID = "4";
 const CREATE_TICKET_ENDPOINT = `${ZAMMAD_URL}/api/v1/tickets`;
 const EMAIL_TYPE_ID = 1;
-const FROM_MON_COMPTE_PRO = "MonComptePro";
 const GROUP_MON_COMPTE_PRO = "MonComptePro";
 const GROUP_MON_COMPTE_PRO_SENDER_ID = 1;
 const MODERATION_TAG = "moderation";
@@ -25,15 +24,11 @@ export async function sendZammadMail({
   subject,
   template,
   params,
-  senderEmail = "moncomptepro@beta.gouv.fr",
 }: {
   to: string[];
   cc?: string[];
   subject: string;
-  template: LocalTemplateSlug;
-  params: any;
-  senderEmail?: string;
-}) {
+} & LocalTemplate) {
   const body = await render(
     path.resolve(`${__dirname}/../views/mails/${template}.ejs`),
     params,

--- a/src/connectors/sendinblue.ts
+++ b/src/connectors/sendinblue.ts
@@ -19,20 +19,6 @@ type LocalTemplateSlug =
   | "welcome"
   | "moderation-processed";
 
-export type LocalTemplate =
-  | {
-      template: "unable-to-auto-join-organization";
-      params: { libelle: string };
-    }
-  | {
-      template: "unable-to-find-sponsor";
-      params: {
-        given_name: string;
-        family_name: string;
-        libelle: string;
-      };
-    };
-
 // active templates id are listed at https://app-smtp.sendinblue.com/templates
 const remoteTemplateSlugToSendinblueTemplateId: {
   [k in RemoteTemplateSlug]: number;

--- a/src/connectors/sendinblue.ts
+++ b/src/connectors/sendinblue.ts
@@ -57,6 +57,37 @@ export async function sendZammadMail({
 }) {
   const CREATE_TICKET_ENDPOINT = `${ZAMMAD_URL}/api/v1/tickets`;
   console.log("Sending mail to Zammad ", CREATE_TICKET_ENDPOINT);
+
+  const data = {
+    cc: undefined as { email: string }[] | undefined,
+    sender: {
+      name: "L’équipe MonComptePro",
+      email: senderEmail,
+    },
+    replyTo: {
+      name: "L’équipe MonComptePro",
+      email: senderEmail,
+    },
+    // Sendinblue allow a maximum of 99 recipients
+    to: chain(to)
+      .sampleSize(99)
+      .map((e) => ({ email: e }))
+      .value(),
+    subject,
+    params,
+    tags: [template],
+    headers: {
+      charset: "iso-8859-1",
+    },
+    templateId: 0,
+  };
+
+  if (DO_NOT_SEND_MAIL) {
+    console.log(`${template} mail not send to ${to}:`);
+    console.log(data);
+    return;
+  }
+
   return Promise.reject("Not implemented");
 }
 

--- a/src/connectors/sendinblue.ts
+++ b/src/connectors/sendinblue.ts
@@ -1,10 +1,13 @@
 import axios, { AxiosError, AxiosResponse } from "axios";
 import { chain, isEmpty } from "lodash";
 import path from "path";
-
-import { render } from "../services/renderer";
+import {
+  DO_NOT_SEND_MAIL,
+  SENDINBLUE_API_KEY,
+  ZAMMAD_URL,
+} from "../config/env";
 import { SendInBlueApiError } from "../config/errors";
-import { DO_NOT_SEND_MAIL, SENDINBLUE_API_KEY } from "../config/env";
+import { render } from "../services/renderer";
 
 type RemoteTemplateSlug =
   | "join-organization"
@@ -37,6 +40,26 @@ const hasRemoteTemplate = (
 ): template is RemoteTemplateSlug =>
   remoteTemplateSlugToSendinblueTemplateId.hasOwnProperty(template);
 
+export async function sendZammadMail({
+  to = [],
+  cc = [],
+  subject,
+  template,
+  params,
+  senderEmail = "moncomptepro@beta.gouv.fr",
+}: {
+  to: string[];
+  cc?: string[];
+  subject: string;
+  template: RemoteTemplateSlug | LocalTemplateSlug;
+  params: any;
+  senderEmail?: string;
+}) {
+  const CREATE_TICKET_ENDPOINT = `${ZAMMAD_URL}/api/v1/tickets`;
+  console.log("Sending mail to Zammad ", CREATE_TICKET_ENDPOINT);
+  return Promise.reject("Not implemented");
+}
+
 export const sendMail = async ({
   to = [],
   cc = [],
@@ -53,6 +76,7 @@ export const sendMail = async ({
   senderEmail?: string;
 }) => {
   const data = {
+    cc: [] as { email: string }[],
     sender: {
       name: "L’équipe MonComptePro",
       email: senderEmail,
@@ -88,7 +112,6 @@ export const sendMail = async ({
   }
 
   if (!isEmpty(cc)) {
-    // @ts-ignore
     data.cc = cc.map((e) => ({ email: e }));
   }
 

--- a/src/connectors/sendinblue.ts
+++ b/src/connectors/sendinblue.ts
@@ -19,10 +19,19 @@ type LocalTemplateSlug =
   | "welcome"
   | "moderation-processed";
 
-export type LocalTemplate = {
-  template: "unable-to-auto-join-organization";
-  params: { libelle: string };
-};
+export type LocalTemplate =
+  | {
+      template: "unable-to-auto-join-organization";
+      params: { libelle: string };
+    }
+  | {
+      template: "unable-to-find-sponsor";
+      params: {
+        given_name: string;
+        family_name: string;
+        libelle: string;
+      };
+    };
 
 // active templates id are listed at https://app-smtp.sendinblue.com/templates
 const remoteTemplateSlugToSendinblueTemplateId: {

--- a/src/connectors/sendinblue.ts
+++ b/src/connectors/sendinblue.ts
@@ -5,14 +5,14 @@ import { DO_NOT_SEND_MAIL, SENDINBLUE_API_KEY } from "../config/env";
 import { SendInBlueApiError } from "../config/errors";
 import { render } from "../services/renderer";
 
-export type RemoteTemplateSlug =
+type RemoteTemplateSlug =
   | "join-organization"
   | "verify-email"
   | "reset-password"
   | "magic-link"
   | "choose-sponsor"
   | "official-contact-email-verification";
-export type LocalTemplateSlug =
+type LocalTemplateSlug =
   | "organization-welcome"
   | "unable-to-auto-join-organization"
   | "unable-to-find-sponsor"

--- a/src/connectors/sendinblue.ts
+++ b/src/connectors/sendinblue.ts
@@ -19,6 +19,11 @@ export type LocalTemplateSlug =
   | "welcome"
   | "moderation-processed";
 
+export type LocalTemplate = {
+  template: "unable-to-auto-join-organization";
+  params: { libelle: string };
+};
+
 // active templates id are listed at https://app-smtp.sendinblue.com/templates
 const remoteTemplateSlugToSendinblueTemplateId: {
   [k in RemoteTemplateSlug]: number;

--- a/src/connectors/sendinblue.ts
+++ b/src/connectors/sendinblue.ts
@@ -76,7 +76,7 @@ export const sendMail = async ({
   senderEmail?: string;
 }) => {
   const data = {
-    cc: [] as { email: string }[],
+    cc: undefined as { email: string }[] | undefined,
     sender: {
       name: "L’équipe MonComptePro",
       email: senderEmail,

--- a/src/connectors/sendinblue.ts
+++ b/src/connectors/sendinblue.ts
@@ -1,22 +1,18 @@
 import axios, { AxiosError, AxiosResponse } from "axios";
 import { chain, isEmpty } from "lodash";
 import path from "path";
-import {
-  DO_NOT_SEND_MAIL,
-  SENDINBLUE_API_KEY,
-  ZAMMAD_URL,
-} from "../config/env";
+import { DO_NOT_SEND_MAIL, SENDINBLUE_API_KEY } from "../config/env";
 import { SendInBlueApiError } from "../config/errors";
 import { render } from "../services/renderer";
 
-type RemoteTemplateSlug =
+export type RemoteTemplateSlug =
   | "join-organization"
   | "verify-email"
   | "reset-password"
   | "magic-link"
   | "choose-sponsor"
   | "official-contact-email-verification";
-type LocalTemplateSlug =
+export type LocalTemplateSlug =
   | "organization-welcome"
   | "unable-to-auto-join-organization"
   | "unable-to-find-sponsor"
@@ -39,57 +35,6 @@ const hasRemoteTemplate = (
   template: RemoteTemplateSlug | LocalTemplateSlug,
 ): template is RemoteTemplateSlug =>
   remoteTemplateSlugToSendinblueTemplateId.hasOwnProperty(template);
-
-export async function sendZammadMail({
-  to = [],
-  cc = [],
-  subject,
-  template,
-  params,
-  senderEmail = "moncomptepro@beta.gouv.fr",
-}: {
-  to: string[];
-  cc?: string[];
-  subject: string;
-  template: RemoteTemplateSlug | LocalTemplateSlug;
-  params: any;
-  senderEmail?: string;
-}) {
-  const CREATE_TICKET_ENDPOINT = `${ZAMMAD_URL}/api/v1/tickets`;
-  console.log("Sending mail to Zammad ", CREATE_TICKET_ENDPOINT);
-
-  const data = {
-    cc: undefined as { email: string }[] | undefined,
-    sender: {
-      name: "L’équipe MonComptePro",
-      email: senderEmail,
-    },
-    replyTo: {
-      name: "L’équipe MonComptePro",
-      email: senderEmail,
-    },
-    // Sendinblue allow a maximum of 99 recipients
-    to: chain(to)
-      .sampleSize(99)
-      .map((e) => ({ email: e }))
-      .value(),
-    subject,
-    params,
-    tags: [template],
-    headers: {
-      charset: "iso-8859-1",
-    },
-    templateId: 0,
-  };
-
-  if (DO_NOT_SEND_MAIL) {
-    console.log(`${template} mail not send to ${to}:`);
-    console.log(data);
-    return;
-  }
-
-  return Promise.reject("Not implemented");
-}
 
 export const sendMail = async ({
   to = [],

--- a/src/managers/organization/authentication-by-peers.ts
+++ b/src/managers/organization/authentication-by-peers.ts
@@ -355,5 +355,6 @@ export const askForSponsorship = async ({
     user_id,
     organization_id,
     type: "ask_for_sponsorship",
+    ticket_id: ticket.id,
   });
 };

--- a/src/managers/organization/authentication-by-peers.ts
+++ b/src/managers/organization/authentication-by-peers.ts
@@ -350,6 +350,6 @@ export const askForSponsorship = async ({
     user_id,
     organization_id,
     type: "ask_for_sponsorship",
-    ticket_id: Number.isNaN(ticket.id) ? null : ticket.id,
+    ticket_id: ticket.id,
   });
 };

--- a/src/managers/organization/authentication-by-peers.ts
+++ b/src/managers/organization/authentication-by-peers.ts
@@ -5,9 +5,8 @@ import {
 } from "../../config/env";
 import {
   NotFoundError,
-  SendZammadApiError,
   UserAlreadyAskedForSponsorshipError,
-  UserHasAlreadyBeenAuthenticatedByPeers,
+  UserHasAlreadyBeenAuthenticatedByPeers
 } from "../../config/errors";
 import { sendZammadMail } from "../../connectors/sendZammadMail";
 import { sendMail } from "../../connectors/sendinblue";
@@ -347,14 +346,10 @@ export const askForSponsorship = async ({
     },
   });
 
-  if (!ticket) {
-    throw new SendZammadApiError("Unable to create ticket");
-  }
-
   await createModeration({
     user_id,
     organization_id,
     type: "ask_for_sponsorship",
-    ticket_id: ticket.id,
+    ticket_id: Number.isNaN(ticket.id) ? null : ticket.id,
   });
 };

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -276,6 +276,7 @@ export const joinOrganization = async ({
       user_id,
       organization_id,
       type: "non_verified_domain",
+      ticket_id: null,
     });
     return await linkUserToOrganization({
       organization_id,
@@ -301,6 +302,7 @@ export const joinOrganization = async ({
     user_id,
     organization_id,
     type: "organization_join_block",
+    ticket_id: ticket.id,
   });
 
   throw new UnableToAutoJoinOrganizationError();

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -1,16 +1,6 @@
-import {
-  getEmailDomain,
-  isAFreeEmailProvider,
-  usesAFreeEmailProvider,
-} from "../../services/uses-a-free-email-provider";
+import * as Sentry from "@sentry/node";
 import { isEmpty, some, uniqBy } from "lodash";
-import {
-  findById as findOrganizationById,
-  findByMostUsedEmailDomain,
-  findByUserId,
-  findByVerifiedEmailDomain,
-} from "../../repositories/organization/getters";
-import { findById as findUserById } from "../../repositories/user";
+import { SUPPORT_EMAIL_ADDRESS } from "../../config/env";
 import {
   InseeConnectionError,
   InseeNotActiveError,
@@ -21,16 +11,26 @@ import {
   UserInOrganizationAlreadyError,
   UserNotFoundError,
 } from "../../config/errors";
+import { getAnnuaireEducationNationaleContactEmail } from "../../connectors/api-annuaire-education-nationale";
+import { getAnnuaireServicePublicContactEmail } from "../../connectors/api-annuaire-service-public";
+import { getOrganizationInfo } from "../../connectors/api-sirene";
+import { sendMail } from "../../connectors/sendinblue";
+import {
+  createModeration,
+  findPendingModeration,
+} from "../../repositories/moderation";
+import {
+  findByMostUsedEmailDomain,
+  findByUserId,
+  findByVerifiedEmailDomain,
+  findById as findOrganizationById,
+} from "../../repositories/organization/getters";
 import {
   addAuthorizedDomain,
   linkUserToOrganization,
   upsert,
 } from "../../repositories/organization/setters";
-import { getOrganizationInfo } from "../../connectors/api-sirene";
-import {
-  createModeration,
-  findPendingModeration,
-} from "../../repositories/moderation";
+import { findById as findUserById } from "../../repositories/user";
 import {
   hasLessThanFiftyEmployees,
   isCommune,
@@ -38,13 +38,13 @@ import {
   isEntrepriseUnipersonnelle,
   isEtablissementScolaireDuPremierEtSecondDegre,
 } from "../../services/organization";
-import { getAnnuaireServicePublicContactEmail } from "../../connectors/api-annuaire-service-public";
-import * as Sentry from "@sentry/node";
 import { isEmailValid } from "../../services/security";
+import {
+  getEmailDomain,
+  isAFreeEmailProvider,
+  usesAFreeEmailProvider,
+} from "../../services/uses-a-free-email-provider";
 import { markDomainAsVerified } from "./main";
-import { sendMail } from "../../connectors/sendinblue";
-import { SUPPORT_EMAIL_ADDRESS } from "../../config/env";
-import { getAnnuaireEducationNationaleContactEmail } from "../../connectors/api-annuaire-education-nationale";
 
 export const doSuggestOrganizations = async ({
   user_id,

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -19,7 +19,7 @@ import {
   findPendingModeration,
 } from "../../repositories/moderation";
 import {
-  findById as findOrganizationById,
+  findById,
   findByMostUsedEmailDomain,
   findByUserId,
   findByVerifiedEmailDomain,
@@ -308,7 +308,7 @@ export const forceJoinOrganization = async ({
   is_external?: boolean;
 }) => {
   const user = await findUserById(user_id);
-  const organization = await findOrganizationById(organization_id);
+  const organization = await findById(organization_id);
   if (isEmpty(user) || isEmpty(organization)) {
     throw new NotFoundError();
   }

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -1,6 +1,5 @@
 import * as Sentry from "@sentry/node";
 import { isEmpty, some, uniqBy } from "lodash";
-import { SUPPORT_EMAIL_ADDRESS } from "../../config/env";
 import {
   InseeConnectionError,
   InseeNotActiveError,
@@ -14,7 +13,7 @@ import {
 import { getAnnuaireEducationNationaleContactEmail } from "../../connectors/api-annuaire-education-nationale";
 import { getAnnuaireServicePublicContactEmail } from "../../connectors/api-annuaire-service-public";
 import { getOrganizationInfo } from "../../connectors/api-sirene";
-import { sendMail } from "../../connectors/sendinblue";
+import { sendZammadMail } from "../../connectors/sendinblue";
 import {
   createModeration,
   findPendingModeration,
@@ -289,9 +288,8 @@ export const joinOrganization = async ({
     organization_id,
     type: "organization_join_block",
   });
-  await sendMail({
+  await sendZammadMail({
     to: [email],
-    cc: [SUPPORT_EMAIL_ADDRESS],
     subject: `[MonComptePro] Demande pour rejoindre ${cached_libelle || siret}`,
     template: "unable-to-auto-join-organization",
     params: {

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -289,7 +289,7 @@ export const joinOrganization = async ({
     type: "organization_join_block",
   });
   await sendZammadMail({
-    to: [email],
+    to: email,
     subject: `[MonComptePro] Demande pour rejoindre ${cached_libelle || siret}`,
     template: "unable-to-auto-join-organization",
     params: {

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -297,7 +297,7 @@ export const joinOrganization = async ({
     user_id,
     organization_id,
     type: "organization_join_block",
-    ticket_id: Number.isNaN(ticket.id) ? null : ticket.id,
+    ticket_id: ticket.id,
   });
 
   throw new UnableToAutoJoinOrganizationError();

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -13,7 +13,7 @@ import {
 import { getAnnuaireEducationNationaleContactEmail } from "../../connectors/api-annuaire-education-nationale";
 import { getAnnuaireServicePublicContactEmail } from "../../connectors/api-annuaire-service-public";
 import { getOrganizationInfo } from "../../connectors/api-sirene";
-import { sendZammadMail } from "../../connectors/sendinblue";
+import { sendZammadMail } from "../../connectors/sendZammadMail";
 import {
   createModeration,
   findPendingModeration,

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -5,11 +5,10 @@ import {
   InseeNotActiveError,
   InvalidSiretError,
   NotFoundError,
-  SendZammadApiError,
   UnableToAutoJoinOrganizationError,
   UserAlreadyAskedToJoinOrganizationError,
   UserInOrganizationAlreadyError,
-  UserNotFoundError,
+  UserNotFoundError
 } from "../../config/errors";
 import { getAnnuaireEducationNationaleContactEmail } from "../../connectors/api-annuaire-education-nationale";
 import { getAnnuaireServicePublicContactEmail } from "../../connectors/api-annuaire-service-public";
@@ -294,15 +293,11 @@ export const joinOrganization = async ({
     },
   });
 
-  if (!ticket) {
-    throw new SendZammadApiError("Unable to create ticket");
-  }
-
   await createModeration({
     user_id,
     organization_id,
     type: "organization_join_block",
-    ticket_id: ticket.id,
+    ticket_id: Number.isNaN(ticket.id) ? null : ticket.id,
   });
 
   throw new UnableToAutoJoinOrganizationError();

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -19,10 +19,10 @@ import {
   findPendingModeration,
 } from "../../repositories/moderation";
 import {
+  findById as findOrganizationById,
   findByMostUsedEmailDomain,
   findByUserId,
   findByVerifiedEmailDomain,
-  findById as findOrganizationById,
 } from "../../repositories/organization/getters";
 import {
   addAuthorizedDomain,

--- a/src/repositories/moderation.ts
+++ b/src/repositories/moderation.ts
@@ -10,7 +10,7 @@ export const createModeration = async ({
   user_id: number;
   organization_id: number;
   type: Moderation["type"];
-  ticket_id: number;
+  ticket_id: number | null;
 }) => {
   const connection = getDatabaseConnection();
 

--- a/src/repositories/moderation.ts
+++ b/src/repositories/moderation.ts
@@ -16,7 +16,7 @@ export const createModeration = async ({
 
   const { rows }: QueryResult<Moderation> = await connection.query(
     `
-INSERT INTO moderations (user_id, organization_id, type)
+INSERT INTO moderations (user_id, organization_id, type, ticket_id)
 VALUES ($1, $2, $3, $4)
 RETURNING *;`,
     [user_id, organization_id, type, ticket_id],

--- a/src/repositories/moderation.ts
+++ b/src/repositories/moderation.ts
@@ -17,7 +17,7 @@ export const createModeration = async ({
   const { rows }: QueryResult<Moderation> = await connection.query(
     `
 INSERT INTO moderations (user_id, organization_id, type)
-VALUES ($1, $2, $3)
+VALUES ($1, $2, $3, $4)
 RETURNING *;`,
     [user_id, organization_id, type, ticket_id],
   );

--- a/src/repositories/moderation.ts
+++ b/src/repositories/moderation.ts
@@ -1,14 +1,16 @@
-import { getDatabaseConnection } from "../connectors/postgres";
 import { QueryResult } from "pg";
+import { getDatabaseConnection } from "../connectors/postgres";
 
 export const createModeration = async ({
   user_id,
   organization_id,
   type,
+  ticket_id,
 }: {
   user_id: number;
   organization_id: number;
   type: Moderation["type"];
+  ticket_id: number;
 }) => {
   const connection = getDatabaseConnection();
 
@@ -17,7 +19,7 @@ export const createModeration = async ({
 INSERT INTO moderations (user_id, organization_id, type)
 VALUES ($1, $2, $3)
 RETURNING *;`,
-    [user_id, organization_id, type],
+    [user_id, organization_id, type, ticket_id],
   );
 
   return rows.shift()!;


### PR DESCRIPTION
<p align="center">
    <img src="https://media.giphy.com/media/3oEdv9OpWdiMIcCnYc/giphy.gif">
</p>

---

This PR allow moncomptepro to send mail through Zammad.

Note that the ci is doing **real case test** resulting on actual Zammad Tickets on our Zammad. We might want to find a way to use a fake/test zammad instance to reduce the noise on our side.

---

BREAKING CHANGE: Require additional ZAMMAD env variables.

```ini
ZAMMAD_URL=http://zammad/
ZAMMAD_TOKEN=your_zammad_token
```