### PR TITLE
add MTE organization to beta.gouv domain email

### DIFF
--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -155,7 +155,8 @@ VALUES
   (39, '21930066200018', '{}', '{"yopmail.com"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   (40, '21950127700897', '{}', '{"yopmail.com"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   (41, '21590512600011', '{"moncourrier.fr.nf"}', '{"moncourrier.fr.nf"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (42, '81403721400016', '{"yeswehack.ninja"}', '{"yeswehack.ninja"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+  (42, '81403721400016', '{"yeswehack.ninja"}', '{"yeswehack.ninja"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (43, '11006801200050', '{"beta.gouv.fr"}', '{"beta.gouv.fr"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
 ON CONFLICT (id)
   DO UPDATE
   SET (siret, verified_email_domains, authorized_email_domains, created_at, updated_at)


### PR DESCRIPTION
Avec ceci, les gens avec une adresse email en beta.gouv.fr pourront rejoindre le MTE.

TEMPORAIRE.