### PR TITLE
Grist - remove `organizations` scope

### DIFF
--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -339,7 +339,7 @@ VALUES
      'http://localhost:8484',
      'http://localhost:8484/o/docs/signed-out'
      ],
-   'openid email organization organizations profile',
+   'openid email organization profile',
    'https://grist.dev.incubateur.anct.gouv.fr',
    'Saisir et manipuler collaborativement les données.',
    null, null, null, null),


### PR DESCRIPTION
This scope is deprecated, we try to remove it in our staging environment.