### PR TITLE
changer délai moyen 3 jours vers 1 jour ouvré

### DIFF
--- a/src/views/mails/unable-to-auto-join-organization.ejs
+++ b/src/views/mails/unable-to-auto-join-organization.ejs
@@ -4,7 +4,7 @@ Bonjour,
 <br /><br />
 Vous recevrez un email pour accéder à votre démarche dès que nous aurons terminé.
 <br /><br />
-<i>(délai moyen : 3 jours)</i>
+<i>(délai moyen : 1 jour ouvré)</i>
 <br /><br />
 Cordialement,
 <br /><br />

--- a/src/views/user/unable-to-auto-join-organization.ejs
+++ b/src/views/user/unable-to-auto-join-organization.ejs
@@ -14,7 +14,7 @@
                         Vous recevrez un email pour accéder à votre démarche dès que nous aurons terminé.
                     </p>
                     <p>
-                        <i>(délai moyen : 3 jours)</i>
+                        <i>(délai moyen : 1 jour ouvré)</i>
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
changer délai moyen de support 3 jours vers 1 jour ouvré.

Cette PR est en vue de tester de raccourcir le délai moyen voir si cela nous ajoute du support à traiter. Vu avec Anaïs : le support sera redirigé vers moi. Si le test est concluant, nous garderons ce délai.

Ceci est en vue de retirer temporairement la notion de délai pour le gros d'Égapro les 5 derniers jours de Février.