### PR TITLE
chore(organizations): use now as default timestamp

### DIFF
--- a/migrations/1707304087954_change-default-organizations-timestamp.js
+++ b/migrations/1707304087954_change-default-organizations-timestamp.js
@@ -1,0 +1,15 @@
+exports.shorthands = undefined;
+
+exports.up = async (pgm) => {
+  await pgm.db.query(`
+    ALTER TABLE "organizations" ALTER COLUMN "created_at" SET DEFAULT now();
+    ALTER TABLE "organizations" ALTER COLUMN "updated_at" SET DEFAULT now();
+  `);
+};
+
+exports.down = async (pgm) => {
+  await pgm.db.query(`
+  ALTER TABLE "organizations" ALTER COLUMN "created_at" SET DEFAULT '1970-01-01 00:00:00'::timestamp without time zone;
+  ALTER TABLE "organizations" ALTER COLUMN "updated_at" SET DEFAULT '1970-01-01 00:00:00'::timestamp without time zone;
+  `);
+};


### PR DESCRIPTION
<p align="center">
    <img src="https://media.giphy.com/media/9u514UZd57mRhnBCEk/giphy.gif?cid=790b76118qadhlq67nky03j23vtpx5828ughy67l69c7r66v&ep=v1_gifs_search&rid=giphy.gif&ct=g">
</p>

---

We might want to do the same for the `users_organizations` table