### PR TITLE
fix: make the site layout consistent accross all pages

### DIFF
--- a/public/application_20240126.css
+++ b/public/application_20240126.css
@@ -1,24 +1,12 @@
-header {
-    grid-area: header;
-}
-
-main {
-    grid-area: main;
-}
-
-footer {
-    grid-area: footer;
-}
-
 body {
     min-height: 100vh;
     background-color: #ffffff;
-    display: grid;
-    grid-template-columns: 100%;
-    grid-template-areas:
-    'header'
-    'main'
-    'footer';
+    display: flex;
+    flex-direction: column;
+}
+
+footer {
+  margin-top: auto;
 }
 
 .page-container {


### PR DESCRIPTION
Using grid layout as is made the layout move between pages because the main content never has the same height. Now we have a simpler layout, just telling the footer to stay at the bottom, header and main always start at the same place.

Noting this as draft as it's just a quick idea after discovering the project.

Here is a before/after video to see what I mean:


https://github.com/betagouv/moncomptepro/assets/221253/95dde82d-101d-46a1-93ff-01f93dad7c8d

