### PR TITLE
fix(views): remplace mairie by établissement scolaire

### DIFF
--- a/cypress/e2e/join_with_code_sent_to_official_contact_email.cy.js
+++ b/cypress/e2e/join_with_code_sent_to_official_contact_email.cy.js
@@ -26,6 +26,9 @@ describe("join organizations", () => {
     cy.get('[type="submit"]').click();
 
     // Check that the website is waiting for the user to verify their email
+    cy.contains(
+      "nous avons envoyé un code secret à l’adresse email de votre mairie",
+    );
     cy.get("#email-badge-lowercase").contains(
       "26ccc0fa-0dc3-4f12-9335-7bb00282920c@mailslurp.com",
     );

--- a/cypress/e2e/join_with_code_sent_to_official_educ_nat_contact_email.cy.js
+++ b/cypress/e2e/join_with_code_sent_to_official_educ_nat_contact_email.cy.js
@@ -26,6 +26,9 @@ describe("join organizations", () => {
     cy.get('[type="submit"]').click();
 
     // Check that the website is waiting for the user to verify their email
+    cy.contains(
+      "nous avons envoyé un code secret à l’adresse email de votre établissement scolaire",
+    );
     cy.get("#email-badge-lowercase").contains(
       "01714bdb-c5d7-48c9-93ab-73dc78c13609@mailslurp.com",
     );

--- a/src/controllers/user/official-contact-email-verification.ts
+++ b/src/controllers/user/official-contact-email-verification.ts
@@ -17,6 +17,8 @@ import {
 } from "../../config/errors";
 import { getUserFromLoggedInSession } from "../../managers/session";
 import { csrfToken } from "../../middlewares/csrf-protection";
+import { getOrganizationTypeLabel } from "../../services/organization";
+import { getOrganizationById } from "../../managers/organization/main";
 
 export const getOfficialContactEmailVerificationController = async (
   req: Request,
@@ -48,6 +50,9 @@ export const getOfficialContactEmailVerificationController = async (
         checkBeforeSend: true,
       });
 
+    // call to sendOfficialContactEmailVerificationEmail ensure organization exists
+    const organization = (await getOrganizationById(organization_id))!;
+
     return res.render("user/official-contact-email-verification", {
       notifications: await getNotificationsFromRequest(req),
       contactEmail,
@@ -56,6 +61,7 @@ export const getOfficialContactEmailVerificationController = async (
       codeSent,
       libelle,
       organization_id,
+      organization_type_label: getOrganizationTypeLabel(organization),
     });
   } catch (error) {
     if (error instanceof OfficialContactEmailVerificationNotNeededError) {

--- a/src/services/organization.ts
+++ b/src/services/organization.ts
@@ -134,3 +134,26 @@ export const isEducationNationaleDomain = (domain: string) => {
 
   return domain.match(/^ac-[a-zA-Z0-9-]*\.fr$/) !== null;
 };
+
+export const getOrganizationTypeLabel = (organization: Organization) => {
+  if (isEtablissementScolaireDuPremierEtSecondDegre(organization)) {
+    return "établissement scolaire";
+  } else {
+    if (isCommune(organization)) {
+      return "mairie";
+    }
+
+    if (isServicePublic(organization)) {
+      return "service";
+    }
+  }
+
+  if (
+    isEntrepriseUnipersonnelle(organization) &&
+    isWasteManagementOrganization(organization)
+  ) {
+    return "entreprise";
+  }
+
+  return "organisation";
+};

--- a/src/views/user/official-contact-email-verification.ejs
+++ b/src/views/user/official-contact-email-verification.ejs
@@ -10,7 +10,7 @@
                     <form id="verify-email" action="/users/official-contact-email-verification/<%= organization_id %>" method="post" autocomplete="off">
                         <p>
                             Pour vérifier votre appartenance à l’organisation <%= libelle %>,
-                            nous avons envoyé un <% if (newCodeSent) { %>nouveau <% } %>code secret à l’adresse email de votre mairie :
+                            nous avons envoyé un <% if (newCodeSent) { %>nouveau <% } %>code secret à l’adresse email de votre <%= organization_type_label; %> :
                             <span id="email-badge-lowercase" class="fr-badge fr-badge--info fr-badge--no-icon">
                                 <%= contactEmail; %>
                             </span>.


### PR DESCRIPTION
<p align="center">
    <img src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHljdngyMXZ5aWVwdHZxMGY3a200ZjFrZGI3bXl5MTd1bWxmdGp3cCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/tHufwMDTUi20E/giphy.gif">
</p>

---

\from @Anais-Tailhade 

- [x] should still say "mairie" for town halls
---

Closes https://github.com/betagouv/moncomptepro/issues/465