### PR TITLE
chore: rephrase install doc to prevent confusions with actual *tests*

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -46,13 +46,13 @@ This guide provides steps to run the MonComptePro Node.js application locally wh
    npm run fixtures:load
    ```
 
-5. **Run the Application**: Start the Node.js server with:
+## Running the Application
 
-   ```bash
-   npm run dev
-   ```
+After setting up the application, start the Node.js server with:
 
-## Testing the Application
+```bash
+npm run dev
+```
 
 The application is now available at http://localhost:3000.
 


### PR DESCRIPTION
A bit nitpicky here but I feel like having a "Testing the Application" heading to talk about the local app url and login info is a bit misleading. As I was just quickly scanning the docs via headings I actually skipped this part at first thinking "I don't need to worry about tests right now".