### PR TITLE
feat: shorten sender email

### DIFF
--- a/src/connectors/brevo.ts
+++ b/src/connectors/brevo.ts
@@ -66,7 +66,7 @@ export const sendMail = async ({
     cc: undefined as { email: string }[] | undefined,
     sender: {
       name: "L’équipe MonComptePro",
-      email: senderEmail || "ne-pas-repondre@email.moncomptepro.beta.gouv.fr",
+      email: senderEmail || "nepasrepondre@email.moncomptepro.beta.gouv.fr",
     },
     replyTo: {
       name: "L’équipe MonComptePro",

--- a/src/views/help.ejs
+++ b/src/views/help.ejs
@@ -27,7 +27,7 @@
                     💡 <b>Vérifiez vos spams</b></li>
                 <li class="fr-mb-3w">Votre organisation utilise une protection contre les spams (comme MailInBlack)<br>
                     💡 <b>Contactez votre fournisseur de mail pour qu’il autorise les emails en provenance de
-                        <i>ne-pas-repondre@email.moncomptepro.beta.gouv.fr</i> (adresse IP : 172.246.41.163)</b>
+                        <i>nepasrepondre@email.moncomptepro.beta.gouv.fr</i> (adresse IP : 172.246.41.163)</b>
                 </li>
                 <% if (locals.csrfToken) { %>
                     <li class="fr-mb-3w">Votre code a expiré ou vous avez perdu l’email qui contenait le code<br>


### PR DESCRIPTION
The sender's email should be shorter than 46 characters to ensure that the "envelope-from" does not exceed 64 characters, thereby preventing the email address format from becoming invalid.