### PR TITLE
chore: update betagouv/moncomptepro-test-client use

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -60,11 +60,10 @@ jobs:
       moncomptepro-standard-client:
         image: ghcr.io/betagouv/moncomptepro-test-client
         ports:
-          - 4000:4000
+          - 4000:3000
         env:
           SITE_TITLE: moncomptepro-standard-client
           HOST: http://localhost:4000
-          PORT: 4000
           MCP_CLIENT_ID: standard_client_id
           MCP_CLIENT_SECRET: standard_client_secret
           MCP_PROVIDER: ${{ env.MONCOMPTEPRO_HOST }}
@@ -73,11 +72,10 @@ jobs:
       moncomptepro-agentconnect-client:
         image: ghcr.io/betagouv/moncomptepro-test-client
         ports:
-          - 4001:4001
+          - 4001:3000
         env:
           SITE_TITLE: moncomptepro-agentconnect-client
           HOST: http://localhost:4001
-          PORT: 4001
           MCP_CLIENT_ID: agentconnect_client_id
           MCP_CLIENT_SECRET: agentconnect_client_secret
           MCP_PROVIDER: ${{ env.MONCOMPTEPRO_HOST }}
@@ -89,11 +87,10 @@ jobs:
       moncomptepro-legacy-client:
         image: ghcr.io/betagouv/moncomptepro-test-client
         ports:
-          - 4002:4002
+          - 4002:3000
         env:
           SITE_TITLE: moncomptepro-legacy-client
           HOST: http://localhost:4002
-          PORT: 4002
           MCP_CLIENT_ID: legacy_client_id
           MCP_CLIENT_SECRET: legacy_client_secret
           MCP_PROVIDER: ${{ env.MONCOMPTEPRO_HOST }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,9 @@ services:
   oidc-test-client:
     image: ghcr.io/betagouv/moncomptepro-test-client
     ports:
-      - "3001:3001"
+      - "3001:3000"
     environment:
       # default env var can be found at https://github.com/betagouv/moncomptepro-test-client/blob/master/.env
-      PORT: 3001
       HOST: http://localhost:3001
       MCP_CLIENT_ID: client_id
       MCP_PROVIDER: http://localhost:3000/


### PR DESCRIPTION
It seems like using the default port fixes test client access