### PR TITLE
chore(dependabot): add weekly bot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
<p align="center">
    <img src="https://media.giphy.com/media/96A4Tfi0hgfG8/giphy.gif?cid=ecf05e47upmk06n73er0r5022d4guzwu5apbv0invkg4xiz0&ep=v1_gifs_search&rid=giphy.gif&ct=g">
</p>

---

Allow bots to update the dependencies on the repo.

@rdubigny If you feel ready. npm dependencies can be updated to ;)

```yaml
  - package-ecosystem: "npm"
    directory: "/"
    labels:
      - dependencies
    schedule:
      interval: "weekly"
```