### PR TITLE
Revert "ci(github): bump ubuntu to 22.04"

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -55,7 +55,7 @@ jobs:
           - redirect_after_session_expiration
           - reset_password
           - join_must_confirm
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     services:
       moncomptepro-standard-client:
         image: ghcr.io/betagouv/moncomptepro-test-client

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     services:
       postgres:
         image: postgres:12.12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
The Ci is in recent PRs is strangely broken. 
This PR is testing if it's related to the latest commit.

---

Reverts betagouv/moncomptepro#542