### PR TITLE
perf(sentry): bring down the sample rate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ if (SENTRY_DSN) {
       new Sentry.Integrations.Postgres(),
     ],
     profilesSampleRate: 0.5,
-    tracesSampleRate: 0.5,
+    tracesSampleRate: 0.2,
   });
 }
 


### PR DESCRIPTION
<p align="center">
    <img src="https://media.giphy.com/media/OVwfSuQXVUUI8/giphy.gif">
</p>

---


Set the APM to 10% with a 20% of transactions sent.

\from https://docs.sentry.io/platforms/javascript/profiling/
> Set profilesSampleRate to 1.0 to profile every transaction.  
Since profilesSampleRate is relative to tracesSampleRate, the final profiling rate can be computed as tracesSampleRate * profilesSampleRate